### PR TITLE
Fix 'must have permission set to 0700' on Windows

### DIFF
--- a/wallet/softwallet/keystore/ks_encrypted.go
+++ b/wallet/softwallet/keystore/ks_encrypted.go
@@ -40,6 +40,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 
 	"github.com/pborman/uuid"
 
@@ -97,7 +98,7 @@ func NewKeystoreEncrypted(keysDirRoot string, scryptN, scryptP int) (KeystoreEnc
 	if err != nil {
 		return KeystoreEncrypted{}, err
 	}
-	if fi.Mode().Perm() != 0700 {
+	if runtime.GOOS != "windows" && fi.Mode().Perm() != 0700 {
 		return KeystoreEncrypted{}, fmt.Errorf("%s must have permission set to 0700", keysDirPath)
 	}
 

--- a/wallet/softwallet/keystore/ks_plain.go
+++ b/wallet/softwallet/keystore/ks_plain.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 
 	"github.com/pborman/uuid"
 	"github.com/thetatoken/ukulele/common"
@@ -30,7 +31,7 @@ func NewKeystorePlain(keysDirRoot string) (KeystorePlain, error) {
 	if err != nil {
 		return KeystorePlain{}, err
 	}
-	if fi.Mode().Perm() != 0700 {
+	if runtime.GOOS != "windows" && fi.Mode().Perm() != 0700 {
 		return KeystorePlain{}, fmt.Errorf("%s must have permission set to 0700", keysDirPath)
 	}
 


### PR DESCRIPTION
The code was testing for CHMOD 0700 on the `.banjo\keys\encrypted` folder.
Windows doesn't have CHMOD.
The code was giving a warning on Windows and prevent you from running the cmd.

There are 3 options to fix the 0700 permission warning.


* Remove the warning a let the client software handle the warning
* Use a library like [go-acl](https://github.com/hectane/go-acl) to test the permission. (it not maintained well)
* Test OS type and don't warn when OS = Windows (This is the solution I used in the fix)