### PR TITLE
Enforce tx index when blocks are indirectly finalized

### DIFF
--- a/blockchain/chain.go
+++ b/blockchain/chain.go
@@ -289,6 +289,11 @@ func (ch *Chain) FinalizePreviousBlocks(hash common.Hash) error {
 		if err != nil {
 			logger.Panic(err)
 		}
+
+		// Force update TX index on block finalization so that the index doesn't point to
+		// duplicate TX in fork.
+		ch.AddTxsToIndex(block, true)
+
 		hash = block.Parent
 	}
 	return nil


### PR DESCRIPTION
Fix the glitch reported by rene