### PR TITLE
Rollingdb

### DIFF
--- a/cmd/theta/cmd/start.go
+++ b/cmd/theta/cmd/start.go
@@ -26,6 +26,7 @@ import (
 	"github.com/thetatoken/theta/rlp"
 	"github.com/thetatoken/theta/snapshot"
 	"github.com/thetatoken/theta/store/database/backend"
+	"github.com/thetatoken/theta/store/rollingdb"
 	"github.com/thetatoken/theta/version"
 	ks "github.com/thetatoken/theta/wallet/softwallet/keystore"
 )
@@ -62,6 +63,8 @@ func runStart(cmd *cobra.Command, args []string) {
 	db, err := backend.NewLDBDatabase(mainDBPath, refDBPath,
 		viper.GetInt(common.CfgStorageLevelDBCacheSize),
 		viper.GetInt(common.CfgStorageLevelDBHandles))
+
+	rdb := rollingdb.NewRollingDB(dbPath, db)
 
 	if err != nil {
 		log.Fatalf("Failed to connect to the db. main: %v, ref: %v, err: %v",
@@ -139,6 +142,7 @@ func runStart(cmd *cobra.Command, args []string) {
 		NetworkOld:          networkOld,
 		Network:             network,
 		DB:                  db,
+		RollingDB:           rdb,
 		SnapshotPath:        snapshotPath,
 		ChainImportDirPath:  chainImportDirPath,
 		ChainCorrectionPath: chainCorrectionPath,

--- a/common/config.go
+++ b/common/config.go
@@ -47,6 +47,8 @@ const (
 	CfgStorageLevelDBCacheSize = "storage.levelDBCacheSize"
 	// CfgStorageLevelDBHandles indicates Level DB handle count
 	CfgStorageLevelDBHandles = "storage.levelDBHandles"
+	// CfgStorageRollingInterval is the block interval that we start new db layer
+	CfgStorageRollingInterval = "storage.rollingInterval"
 
 	// CfgSyncMessageQueueSize defines the capacity of Sync Manager message queue.
 	CfgSyncMessageQueueSize = "sync.messageQueueSize"
@@ -172,6 +174,8 @@ func init() {
 	viper.SetDefault(CfgStorageStatePruningSkipCheckpoints, true)
 	viper.SetDefault(CfgStorageLevelDBCacheSize, 256)
 	viper.SetDefault(CfgStorageLevelDBHandles, 16)
+	viper.SetDefault(CfgStorageRollingInterval, 100)
+	// viper.SetDefault(CfgStorageRollingInterval, 10000)
 
 	viper.SetDefault(CfgRPCEnabled, false)
 	viper.SetDefault(CfgP2PMessageQueueSize, 512)

--- a/common/config.go
+++ b/common/config.go
@@ -174,8 +174,7 @@ func init() {
 	viper.SetDefault(CfgStorageStatePruningSkipCheckpoints, true)
 	viper.SetDefault(CfgStorageLevelDBCacheSize, 256)
 	viper.SetDefault(CfgStorageLevelDBHandles, 16)
-	viper.SetDefault(CfgStorageRollingInterval, 100)
-	// viper.SetDefault(CfgStorageRollingInterval, 10000)
+	viper.SetDefault(CfgStorageRollingInterval, 10000)
 
 	viper.SetDefault(CfgRPCEnabled, false)
 	viper.SetDefault(CfgP2PMessageQueueSize, 512)

--- a/common/config.go
+++ b/common/config.go
@@ -35,6 +35,8 @@ const (
 	// CfgConsensusPassThroughGuardianVote defines the how guardian vote is handled.
 	CfgConsensusPassThroughGuardianVote = "consensus.passThroughGuardianVote"
 
+	// CfgStorageRollingEnabled indicates whether rolling is enabled
+	CfgStorageRollingEnabled = "storage.stateRollingEnabled"
 	// CfgStorageStatePruningEnabled indicates whether state pruning is enabled
 	CfgStorageStatePruningEnabled = "storage.statePruningEnabled"
 	// CfgStorageStatePruningInterval indicates the purning interval (in terms of blocks)
@@ -168,6 +170,7 @@ func init() {
 	viper.SetDefault(CfgSyncDownloadByHash, false)
 	viper.SetDefault(CfgSyncDownloadByHeader, true)
 
+	viper.SetDefault(CfgStorageRollingEnabled, true)
 	viper.SetDefault(CfgStorageStatePruningEnabled, true)
 	viper.SetDefault(CfgStorageStatePruningInterval, 16)
 	viper.SetDefault(CfgStorageStatePruningRetainedBlocks, 2048)

--- a/consensus/engine.go
+++ b/consensus/engine.go
@@ -1308,22 +1308,25 @@ func (e *ConsensusEngine) propose() {
 }
 
 func (e *ConsensusEngine) pruneState(currentBlockHeight uint64) {
-	if !viper.GetBool(common.CfgStorageStatePruningEnabled) {
-		return
-	}
+	// Permanently disabled
+	return
 
-	pruneInterval := uint64(viper.GetInt(common.CfgStorageStatePruningInterval))
-	if currentBlockHeight%pruneInterval != 0 {
-		return
-	}
+	// if !viper.GetBool(common.CfgStorageStatePruningEnabled) {
+	// 	return
+	// }
 
-	minimumNumBlocksToRetain := uint64(viper.GetInt(common.CfgStorageStatePruningRetainedBlocks))
-	if currentBlockHeight <= minimumNumBlocksToRetain+1 {
-		return
-	}
+	// pruneInterval := uint64(viper.GetInt(common.CfgStorageStatePruningInterval))
+	// if currentBlockHeight%pruneInterval != 0 {
+	// 	return
+	// }
 
-	endHeight := currentBlockHeight - minimumNumBlocksToRetain
-	e.ledger.PruneState(endHeight)
+	// minimumNumBlocksToRetain := uint64(viper.GetInt(common.CfgStorageStatePruningRetainedBlocks))
+	// if currentBlockHeight <= minimumNumBlocksToRetain+1 {
+	// 	return
+	// }
+
+	// endHeight := currentBlockHeight - minimumNumBlocksToRetain
+	// e.ledger.PruneState(endHeight)
 }
 
 func (e *ConsensusEngine) State() *State {

--- a/ledger/execution/testutils.go
+++ b/ledger/execution/testutils.go
@@ -109,7 +109,7 @@ func (et *execTest) reset() {
 		},
 	}
 	db := backend.NewMemDatabase()
-	ledgerState := st.NewLedgerState(chainID, db)
+	ledgerState := st.NewLedgerState(chainID, db, nil)
 	//ledgerState.ResetState(initHeight, initRootHash)
 	ledgerState.ResetState(initBlock)
 

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -47,8 +47,8 @@ type Ledger struct {
 }
 
 // NewLedger creates an instance of Ledger
-func NewLedger(chainID string, db database.Database, chain *blockchain.Chain, consensus core.ConsensusEngine, valMgr core.ValidatorManager, mempool *mp.Mempool) *Ledger {
-	state := st.NewLedgerState(chainID, db)
+func NewLedger(chainID string, db database.Database, tagger st.Tagger, chain *blockchain.Chain, consensus core.ConsensusEngine, valMgr core.ValidatorManager, mempool *mp.Mempool) *Ledger {
+	state := st.NewLedgerState(chainID, db, tagger)
 	executor := exec.NewExecutor(db, chain, state, consensus, valMgr)
 	ledger := &Ledger{
 		db:        db,

--- a/ledger/ledger.go
+++ b/ledger/ledger.go
@@ -434,46 +434,49 @@ func (ledger *Ledger) ApplyBlockTxsForChainCorrection(block *core.Block) (common
 
 // PruneState attempts to prune the state up to the targetEndHeight
 func (ledger *Ledger) PruneState(targetEndHeight uint64) error {
-	var processedHeight uint64
-	db := ledger.State().DB()
-	kvStore := kvstore.NewKVStore(db)
-	err := kvStore.Get(state.StatePruningProgressKey(), &processedHeight)
-	if err != nil {
-		processedHeight = ledger.chain.Root().Height
-	}
-
-	pruneInterval := uint64(viper.GetInt(common.CfgStorageStatePruningInterval))
-	maxHeightsToPrune := 3 * pruneInterval // prune too many heights at once could cause hang, should catchup gradually
-	endHeight := processedHeight + maxHeightsToPrune
-	if endHeight > targetEndHeight {
-		endHeight = targetEndHeight
-	}
-
-	startHeight := processedHeight + 1
-	if endHeight < startHeight {
-		errMsg := fmt.Sprintf("endHeight (%v) < startHeight (%v)", endHeight, startHeight)
-		logger.Warnf(errMsg)
-		return fmt.Errorf(errMsg)
-	}
-
-	lastFinalizedBlock := ledger.consensus.GetLastFinalizedBlock()
-	if endHeight >= lastFinalizedBlock.Height {
-		errMsg := fmt.Sprintf("Can't prune at height >= %v yet", lastFinalizedBlock.Height)
-		logger.Warnf(errMsg)
-		return fmt.Errorf(errMsg)
-	}
-
-	// Need to save the progress before pruning -- in case the program exits during pruning (e.g. Ctrl+C),
-	// the states that are already pruned do not get pruned again
-	kvStore.Put(state.StatePruningProgressKey(), endHeight)
-
-	err = ledger.pruneStateForRange(startHeight, endHeight)
-	if err != nil {
-		logger.Warnf("Unable to pruning state: %v", err)
-		return err
-	}
-
+	// Permanently disabled
 	return nil
+
+	// var processedHeight uint64
+	// db := ledger.State().DB()
+	// kvStore := kvstore.NewKVStore(db)
+	// err := kvStore.Get(state.StatePruningProgressKey(), &processedHeight)
+	// if err != nil {
+	// 	processedHeight = ledger.chain.Root().Height
+	// }
+
+	// pruneInterval := uint64(viper.GetInt(common.CfgStorageStatePruningInterval))
+	// maxHeightsToPrune := 3 * pruneInterval // prune too many heights at once could cause hang, should catchup gradually
+	// endHeight := processedHeight + maxHeightsToPrune
+	// if endHeight > targetEndHeight {
+	// 	endHeight = targetEndHeight
+	// }
+
+	// startHeight := processedHeight + 1
+	// if endHeight < startHeight {
+	// 	errMsg := fmt.Sprintf("endHeight (%v) < startHeight (%v)", endHeight, startHeight)
+	// 	logger.Warnf(errMsg)
+	// 	return fmt.Errorf(errMsg)
+	// }
+
+	// lastFinalizedBlock := ledger.consensus.GetLastFinalizedBlock()
+	// if endHeight >= lastFinalizedBlock.Height {
+	// 	errMsg := fmt.Sprintf("Can't prune at height >= %v yet", lastFinalizedBlock.Height)
+	// 	logger.Warnf(errMsg)
+	// 	return fmt.Errorf(errMsg)
+	// }
+
+	// // Need to save the progress before pruning -- in case the program exits during pruning (e.g. Ctrl+C),
+	// // the states that are already pruned do not get pruned again
+	// kvStore.Put(state.StatePruningProgressKey(), endHeight)
+
+	// err = ledger.pruneStateForRange(startHeight, endHeight)
+	// if err != nil {
+	// 	logger.Warnf("Unable to pruning state: %v", err)
+	// 	return err
+	// }
+
+	// return nil
 }
 
 // pruneStateForRange prunes states from startHeight to endHeight (inclusive for both end)

--- a/ledger/testutils.go
+++ b/ledger/testutils.go
@@ -59,7 +59,7 @@ func newExecSim(chainID string, db database.Database, snapshot mockSnapshot, val
 
 	mempool := mp.CreateMempool(dispatcher, consensus)
 
-	ledgerState := st.NewLedgerState(chainID, db)
+	ledgerState := st.NewLedgerState(chainID, db, nil)
 	//ledgerState.ResetState(initHeight, snapshot.block.StateHash)
 	ledgerState.ResetState(snapshot.block)
 
@@ -199,7 +199,7 @@ func newTestLedger() (chainID string, ledger *Ledger, mempool *mp.Mempool) {
 	p2psimnet := p2psim.NewSimnetWithHandler(nil)
 	messenger := p2psimnet.AddEndpoint(peerID)
 	mempool = newTestMempool(peerID, messenger, nil)
-	ledger = NewLedger(chainID, db, chain, consensus, valMgr, mempool)
+	ledger = NewLedger(chainID, db, nil, chain, consensus, valMgr, mempool)
 	mempool.SetLedger(ledger)
 
 	ctx := context.Background()

--- a/store/rollingdb/copy_trie.go
+++ b/store/rollingdb/copy_trie.go
@@ -1,0 +1,65 @@
+package rollingdb
+
+import (
+	"bytes"
+	"log"
+
+	"github.com/thetatoken/theta/common"
+	"github.com/thetatoken/theta/ledger/state"
+	"github.com/thetatoken/theta/ledger/types"
+	"github.com/thetatoken/theta/store/database"
+	"github.com/thetatoken/theta/store/trie"
+)
+
+func copyState(source database.Database, target database.Batch, root common.Hash) {
+	copyTrie(source, target, root)
+
+	sv := state.NewStoreView(0, root, source)
+
+	sv.GetStore().Traverse(nil, func(k, v common.Bytes) bool {
+		if bytes.HasPrefix(k, []byte("ls/a")) {
+			account := &types.Account{}
+			err := types.FromBytes([]byte(v), account)
+			if err != nil {
+				logger.Errorf("Failed to parse account for %v", []byte(v))
+				panic(err)
+			}
+			if account.Root != (common.Hash{}) {
+				copyTrie(source, target, account.Root)
+			}
+		}
+		return true
+	})
+}
+
+func copyTrie(source database.Database, target database.Batch, root common.Hash) {
+	tr, err := trie.New(root, trie.NewDatabase(source))
+	if err != nil {
+		logger.Panic(err)
+	}
+	it := tr.NodeIterator(nil)
+	for it.Next(true) {
+		if it.Hash() != (common.Hash{}) {
+			hash := it.Hash()
+			val, err := source.Get(hash.Bytes())
+			if err != nil {
+				log.Panic(err)
+			}
+			err = target.Put(hash.Bytes(), val)
+			if err != nil {
+				logger.Panic(err)
+			}
+
+			if target.ValueSize() > database.IdealBatchSize {
+				if err := target.Write(); err != nil {
+					logger.Panicf("Failed to copy trie: %v", err)
+				}
+				target.Reset()
+			}
+
+		}
+	}
+	if err := target.Write(); err != nil {
+		logger.Panicf("Failed to copy trie: %v", err)
+	}
+}

--- a/store/rollingdb/layer.go
+++ b/store/rollingdb/layer.go
@@ -1,0 +1,101 @@
+package rollingdb
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path"
+
+	"github.com/thetatoken/theta/common"
+	"github.com/thetatoken/theta/rlp"
+	"github.com/thetatoken/theta/store/database"
+)
+
+var layerTagKey = []byte("/layertag")
+
+type layerTag struct {
+	Height     uint64
+	StateRoots []common.Hash
+}
+
+type DBLayer struct {
+	dbPath string
+	name   int
+	tag    *layerTag
+	db     database.Database
+}
+
+func NewDBLayer(rollingPath string, name int) *DBLayer {
+	dbPath := path.Join(rollingPath, fmt.Sprintf("%d", name))
+	db, err := NewRawDB(dbPath)
+	if err != nil {
+		logger.Panicf("Failed to create roll db layer, %v", err)
+	}
+
+	l := &DBLayer{
+		dbPath: dbPath,
+		name:   name,
+		db:     db,
+	}
+
+	// Load tag
+	l.tag = l.loadTag()
+
+	return l
+}
+
+func (l *DBLayer) loadTag() *layerTag {
+	layerTag := &layerTag{}
+	raw, err := l.db.Get(layerTagKey)
+	if err == nil {
+		err = rlp.DecodeBytes(raw, layerTag)
+		if err != nil {
+			log.Panicf("Failed to decode layer tag, layer=%v, tag=%v, err=%v", l.name, raw, err)
+		}
+	}
+
+	l.tag = layerTag
+
+	return layerTag
+}
+
+func (l *DBLayer) addTag(height uint64, stateRoot common.Hash) {
+	layerTag := l.loadTag()
+
+	if height < layerTag.Height {
+		return
+	}
+
+	if height == layerTag.Height {
+		for _, root := range layerTag.StateRoots {
+			if root == stateRoot {
+				return
+			}
+		}
+		layerTag.StateRoots = append(layerTag.StateRoots, stateRoot)
+	} else {
+		// height > layerTag.Height
+		layerTag.Height = height
+		layerTag.StateRoots = []common.Hash{stateRoot}
+	}
+
+	l.tag = layerTag
+
+	raw, err := rlp.EncodeToBytes(layerTag)
+	if err != nil {
+		log.Panicf("Failed to encode layer tag, layer=%v, tag=%v, err=%v", l.name, raw, err)
+	}
+	err = l.db.Put(layerTagKey, raw)
+	if err != nil {
+		err = rlp.DecodeBytes(raw, layerTag)
+		if err != nil {
+			log.Panicf("Failed to save layer tag, layer=%v, tag=%v, err=%v", l.name, raw, err)
+		}
+	}
+}
+
+func (l *DBLayer) destroy() {
+	l.db.Close()
+
+	os.RemoveAll(l.dbPath)
+}

--- a/store/rollingdb/layer.go
+++ b/store/rollingdb/layer.go
@@ -87,10 +87,7 @@ func (l *DBLayer) addTag(height uint64, stateRoot common.Hash) {
 	}
 	err = l.db.Put(layerTagKey, raw)
 	if err != nil {
-		err = rlp.DecodeBytes(raw, layerTag)
-		if err != nil {
-			log.Panicf("Failed to save layer tag, layer=%v, tag=%v, err=%v", l.name, raw, err)
-		}
+		log.Panicf("Failed to save layer tag, layer=%v, tag=%v, err=%v", l.name, raw, err)
 	}
 }
 

--- a/store/rollingdb/rawdb.go
+++ b/store/rollingdb/rawdb.go
@@ -1,0 +1,179 @@
+package rollingdb
+
+import (
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/errors"
+	"github.com/syndtr/goleveldb/leveldb/filter"
+	"github.com/syndtr/goleveldb/leveldb/iterator"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/thetatoken/theta/common"
+	"github.com/thetatoken/theta/store"
+	"github.com/thetatoken/theta/store/database"
+)
+
+type RawDB struct {
+	fn string      // filename for reporting
+	db *leveldb.DB // LevelDB instance
+}
+
+const (
+	writePauseWarningThrottler = 1 * time.Minute
+)
+
+var OpenFileLimit = 64
+
+func NewRawDB(file string) (*RawDB, error) {
+	cache := viper.GetInt(common.CfgStorageLevelDBCacheSize)
+	handles := viper.GetInt(common.CfgStorageLevelDBHandles)
+	// Ensure we have some minimal caching and file guarantees
+	if cache < 16 {
+		cache = 16
+	}
+	if handles < 16 {
+		handles = 16
+	}
+	logger.Infof("Allocated cache and file handles, cache: %v, handles: %v", cache, handles)
+
+	// Open the db and recover any potential corruptions
+	db, err := leveldb.OpenFile(file, &opt.Options{
+		OpenFilesCacheCapacity: handles,
+		BlockCacheCapacity:     cache / 2 * opt.MiB,
+		WriteBuffer:            cache / 4 * opt.MiB, // Two of these are used internally
+		Filter:                 filter.NewBloomFilter(10),
+	})
+	if _, corrupted := err.(*errors.ErrCorrupted); corrupted {
+		db, err = leveldb.RecoverFile(file, nil)
+	}
+	// (Re)check for errors and abort if opening of the db failed
+	if err != nil {
+		return nil, err
+	}
+
+	return &RawDB{
+		fn: file,
+		db: db,
+	}, nil
+}
+
+// Path returns the path to the database directory.
+func (db *RawDB) Path() string {
+	return db.fn
+}
+
+// Put puts the given key / value to the queue
+func (db *RawDB) Put(key []byte, value []byte) error {
+	return db.db.Put(key, value, nil)
+}
+
+func (db *RawDB) Has(key []byte) (bool, error) {
+	return db.db.Has(key, nil)
+}
+
+// Get returns the given key if it's present.
+func (db *RawDB) Get(key []byte) ([]byte, error) {
+	dat, err := db.db.Get(key, nil)
+	if err != nil {
+		if err == leveldb.ErrNotFound {
+			return nil, store.ErrKeyNotFound
+		}
+		return nil, err
+	}
+	return dat, nil
+}
+
+// Delete deletes the key from the queue and database
+func (db *RawDB) Delete(key []byte) error {
+	err := db.db.Delete(key, nil)
+	if err != nil && err == leveldb.ErrNotFound {
+		return store.ErrKeyNotFound
+	}
+	return err
+}
+
+func (db *RawDB) Reference(key []byte) error {
+	// NOOP
+	return nil
+}
+
+func (db *RawDB) Dereference(key []byte) error {
+	// NOOP
+	return nil
+}
+
+func (db *RawDB) CountReference(key []byte) (int, error) {
+	// NOOP
+	return 0, nil
+}
+
+func (db *RawDB) NewIterator() iterator.Iterator {
+	return db.db.NewIterator(nil, nil)
+}
+
+// NewIteratorWithPrefix returns a iterator to iterate over subset of database content with a particular prefix.
+func (db *RawDB) NewIteratorWithPrefix(prefix []byte) iterator.Iterator {
+	return db.db.NewIterator(util.BytesPrefix(prefix), nil)
+}
+
+func (db *RawDB) Close() {
+	db.db.Close()
+}
+
+func (db *RawDB) LDB() *leveldb.DB {
+	return db.db
+}
+
+func (db *RawDB) NewBatch() database.Batch {
+	return &rawdbBatch{db: db.db, b: new(leveldb.Batch)}
+}
+
+type rawdbBatch struct {
+	db   *leveldb.DB
+	b    *leveldb.Batch
+	size int
+}
+
+func (b *rawdbBatch) Put(key, value []byte) error {
+	b.b.Put(key, value)
+	b.size += len(value)
+	return nil
+}
+
+func (b *rawdbBatch) Delete(key []byte) error {
+	b.b.Delete(key)
+	b.size += 1
+	return nil
+}
+
+func (b *rawdbBatch) Reference(key []byte) error {
+	// NOOP
+	return nil
+}
+
+func (b *rawdbBatch) Dereference(key []byte) error {
+	// NOOP
+	return nil
+}
+
+func (b *rawdbBatch) Write() error {
+	err := b.db.Write(b.b, nil)
+	if err != nil {
+		return err
+	}
+
+	b.Reset()
+
+	return nil
+}
+
+func (b *rawdbBatch) ValueSize() int {
+	return b.size
+}
+
+func (b *rawdbBatch) Reset() {
+	b.b.Reset()
+	b.size = 0
+}

--- a/store/rollingdb/rollingdb.go
+++ b/store/rollingdb/rollingdb.go
@@ -78,7 +78,7 @@ func (rdb *RollingDB) loadLayers(rollingPath string) (*DBLayer, []*DBLayer) {
 	}
 
 	if len(names) == 0 {
-		if !viper.GetBool(common.CfgStorageStatePruningEnabled) {
+		if !viper.GetBool(common.CfgStorageRollingEnabled) {
 			return rdb.rootLayer, nil
 		}
 		return NewDBLayer(rollingPath, 1), nil
@@ -95,7 +95,7 @@ func (rdb *RollingDB) loadLayers(rollingPath string) (*DBLayer, []*DBLayer) {
 }
 
 func (rdb *RollingDB) Tag(height uint64, stateRoot common.Hash) {
-	if !viper.GetBool(common.CfgStorageStatePruningEnabled) {
+	if !viper.GetBool(common.CfgStorageRollingEnabled) {
 		return
 	}
 
@@ -124,6 +124,10 @@ func (rdb *RollingDB) addLayer() {
 }
 
 func (rdb *RollingDB) compact(height uint64) {
+	if !viper.GetBool(common.CfgStorageStatePruningEnabled) {
+		return
+	}
+
 	select {
 	case rdb.compactC <- struct{}{}: // Make sure there is only one active compaction task
 		logger.Infof("Starting compaction")

--- a/store/rollingdb/rollingdb.go
+++ b/store/rollingdb/rollingdb.go
@@ -1,0 +1,281 @@
+package rollingdb
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"sort"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/spf13/viper"
+	"github.com/thetatoken/theta/blockchain"
+	"github.com/thetatoken/theta/common"
+	"github.com/thetatoken/theta/common/util"
+	"github.com/thetatoken/theta/store/database"
+)
+
+var logger = util.GetLoggerForModule("rollingdb")
+
+type RollingDB struct {
+	mu sync.RWMutex
+
+	parentPath string // path to parent folder
+
+	root  database.Database
+	chain *blockchain.Chain
+
+	rootLayer   *DBLayer
+	layers      []*DBLayer // all layers excluding root layer and active layer, ordered from old to new.
+	activeLayer *DBLayer
+
+	compactC chan struct{}
+}
+
+func NewRollingDB(parentPath string, root database.Database) *RollingDB {
+	rootLayer := &DBLayer{
+		dbPath: path.Join(parentPath, "db"),
+		db:     root,
+		name:   0,
+	}
+
+	rollingPath := path.Join(parentPath, "db", "rolling")
+	_ = os.Mkdir(rollingPath, 0700)
+	activeLayer, layers := loadLayers(rollingPath)
+
+	return &RollingDB{
+		parentPath:  parentPath,
+		root:        root,
+		rootLayer:   rootLayer,
+		layers:      layers,
+		activeLayer: activeLayer,
+		compactC:    make(chan struct{}, 1),
+	}
+}
+
+func (rdb *RollingDB) SetChain(chain *blockchain.Chain) {
+	rdb.chain = chain
+}
+
+func loadLayers(rollingPath string) (*DBLayer, []*DBLayer) {
+	files, err := ioutil.ReadDir(rollingPath)
+	if err != nil {
+		logger.Panicf("Failed to load layers", err)
+	}
+	names := []int{}
+	for _, file := range files {
+		if !file.IsDir() {
+			continue
+		}
+		i, err := strconv.Atoi(file.Name())
+		if err != nil {
+			continue
+		}
+		names = append(names, i)
+	}
+
+	if len(names) == 0 {
+		return NewDBLayer(rollingPath, 1), nil
+	}
+
+	sort.Sort(sort.IntSlice(names))
+	activeLayer := NewDBLayer(rollingPath, names[len(names)-1])
+	layers := []*DBLayer{}
+	for _, name := range names[:len(names)-1] {
+		layer := NewDBLayer(rollingPath, name)
+		layers = append(layers, layer)
+	}
+	return activeLayer, layers
+}
+
+func (rdb *RollingDB) Tag(height uint64, stateRoot common.Hash) {
+	logger.Infof("Tag: height=%v, root=%v", height, stateRoot.Hex())
+	rdb.activeLayer.addTag(height, stateRoot)
+
+	if isRollingHeight(height) {
+		rdb.addLayer()
+	}
+
+	if isCompactionHeight(height) {
+		go rdb.compact()
+	}
+}
+
+func (rdb *RollingDB) addLayer() {
+	rdb.mu.Lock()
+	defer rdb.mu.Unlock()
+
+	rollingPath := path.Join(rdb.parentPath, "db", "rolling")
+
+	rdb.layers = append(rdb.layers, rdb.activeLayer)
+	rdb.activeLayer = NewDBLayer(rollingPath, rdb.activeLayer.name+1)
+}
+
+func (rdb *RollingDB) compact() {
+	select {
+	case rdb.compactC <- struct{}{}: // Make sure there is only one active compaction task
+		logger.Infof("Starting compaction")
+
+		start := time.Now()
+		defer func() {
+			logger.Infof("Compaction finished in %v", time.Since(start))
+		}()
+
+		defer func() {
+			<-rdb.compactC
+		}()
+
+		if len(rdb.layers) == 0 {
+			return
+		}
+
+		lastLayer := rdb.layers[len(rdb.layers)-1]
+
+		if !isRollingHeight(lastLayer.tag.Height) {
+			// potentially db was not cut off cleanly, keep the layer until one cleancut is made
+			logger.Infof("Compaction canceled: lastLayer.name=%v, lastLayer.Height=%v", lastLayer.name, lastLayer.tag.Height)
+			return
+		}
+
+		blocks := rdb.chain.FindBlocksByHeight(lastLayer.tag.Height)
+		for _, block := range blocks {
+			if block.Status.IsFinalized() {
+				for _, stateRoot := range lastLayer.tag.StateRoots {
+					if stateRoot == block.StateHash {
+						logger.Infof("Moving finalized state hash=%v", stateRoot.Hex())
+						copyState(rdb, rdb.activeLayer.db.NewBatch(), stateRoot)
+						break
+					}
+				}
+				break
+			}
+		}
+
+		rdb.mu.Lock()
+		defer rdb.mu.Unlock()
+
+		remainingLayers := []*DBLayer{}
+		for _, layer := range rdb.layers {
+			// New layers might have been added after `lastLayer`
+			if layer.name < lastLayer.name {
+				layer.destroy()
+			} else {
+				remainingLayers = append(remainingLayers, layer)
+			}
+		}
+		rdb.layers = remainingLayers
+	default:
+		return
+	}
+
+}
+
+func isRollingHeight(height uint64) bool {
+	return int(height)%viper.GetInt(common.CfgStorageRollingInterval) == 50
+}
+
+func isCompactionHeight(height uint64) bool {
+	return int(height)%viper.GetInt(common.CfgStorageRollingInterval) == 70
+}
+
+//
+// ------ implements database.Database interface -----
+//
+var _ database.Database = (*RollingDB)(nil)
+
+func (rdb *RollingDB) allLayers() []*DBLayer {
+	ret := []*DBLayer{rdb.activeLayer}
+	ret = append(ret, rdb.layers...)
+	ret = append(ret, rdb.rootLayer)
+	return ret
+}
+
+func (rdb *RollingDB) Get(key []byte) ([]byte, error) {
+	rdb.mu.RLock()
+	defer rdb.mu.RUnlock()
+
+	var err error
+	var result []byte
+
+	for _, layer := range rdb.allLayers() {
+		result, err = layer.db.Get(key)
+		if err == nil {
+			return result, err
+		}
+	}
+	return result, err
+}
+
+func (rdb *RollingDB) Has(key []byte) (bool, error) {
+	rdb.mu.RLock()
+	defer rdb.mu.RUnlock()
+
+	var err error
+	var result bool
+
+	for _, layer := range rdb.allLayers() {
+		result, err = layer.db.Has(key)
+		if err == nil {
+			return result, err
+		}
+	}
+	return result, err
+}
+
+func (rdb *RollingDB) Put(key []byte, value []byte) error {
+	rdb.mu.Lock()
+	defer rdb.mu.Unlock()
+
+	return rdb.activeLayer.db.Put(key, value)
+}
+
+func (rdb *RollingDB) Delete(key []byte) error {
+	rdb.mu.Lock()
+	defer rdb.mu.Unlock()
+
+	// TODO: do we need to delete from all layers?
+	return rdb.activeLayer.db.Delete(key)
+}
+
+func (rdb *RollingDB) Close() {
+	for _, dbLayer := range rdb.layers {
+		dbLayer.db.Close()
+	}
+	rdb.activeLayer.db.Close()
+	// We leave root db to be closed by outer code
+}
+
+type RollingDBBatch struct {
+	database.Batch
+	rdb *RollingDB
+}
+
+func (b *RollingDBBatch) Write() error {
+	b.rdb.mu.Lock()
+	defer b.rdb.mu.Unlock()
+
+	return b.Batch.Write()
+}
+
+func (rdb *RollingDB) NewBatch() database.Batch {
+	return &RollingDBBatch{
+		Batch: rdb.activeLayer.db.NewBatch(),
+		rdb:   rdb,
+	}
+}
+
+func (rdb *RollingDB) CountReference(key []byte) (int, error) {
+	// NOOP
+	return 0, nil
+}
+
+func (rdb *RollingDB) Reference(key []byte) error {
+	// NOOP
+	return nil
+}
+
+func (rdb *RollingDB) Dereference(key []byte) error {
+	// NOOP
+	return nil
+}


### PR DESCRIPTION
Rolling db to keep only recent state tries. By keeping leveldb to a small size, read/write speed is drastically improved.