### PR TITLE
Missing lock in tx.go

### DIFF
--- a/cmd/thetacli/rpc/tx.go
+++ b/cmd/thetacli/rpc/tx.go
@@ -65,6 +65,8 @@ func (t *ThetaCliRPCService) Send(args *SendArgs, result *SendResult) (err error
 		return fmt.Errorf("The from address %v has not been unlocked yet", from.Hex())
 	}
 
+	defer t.wallet.Lock(from)
+
 	inputs := []types.TxInput{{
 		Address: from,
 		Coins: types.Coins{


### PR DESCRIPTION
There is a missing lock in tx.go , after the transaction is done via the RPC , the wallet is not locked hence its kept open to be used without password. If the RPC is exposed an attacker can make tx request without password as the wallet is unlocked. It is recommended to put defer lock , so after the tx is executed wallet is locked again.