### PR TITLE
Fix consensus vote starvation on epoch advance

### DIFF
--- a/consensus/engine.go
+++ b/consensus/engine.go
@@ -298,10 +298,15 @@ func (e *ConsensusEngine) mainLoop() {
 		for {
 			// Drain priority messages (catch-up blocks) before processing regular messages
 			for {
+				e.serviceReadyVoteTimer()
+
 				select {
 				case msg := <-e.priorityIncoming:
+					e.serviceReadyVoteTimer()
+
 					endEpoch := e.processMessage(msg)
 					if endEpoch {
+						e.logLocalVoteTimerNotReadyOnEpochAdvance()
 						break Epoch
 					}
 					continue
@@ -315,20 +320,23 @@ func (e *ConsensusEngine) mainLoop() {
 				e.stopped = true
 				return
 			case msg := <-e.priorityIncoming:
+				e.serviceReadyVoteTimer()
+
 				endEpoch := e.processMessage(msg)
 				if endEpoch {
+					e.logLocalVoteTimerNotReadyOnEpochAdvance()
 					break Epoch
 				}
 			case msg := <-e.incoming:
+				e.serviceReadyVoteTimer()
+
 				endEpoch := e.processMessage(msg)
 				if endEpoch {
+					e.logLocalVoteTimerNotReadyOnEpochAdvance()
 					break Epoch
 				}
 			case <-e.voteTimer.C:
-				e.voteTimerReady = true
-				if e.blockProcessed {
-					e.vote()
-				}
+				e.onVoteTimerReady()
 			case <-e.epochTimer.C:
 				e.logger.WithFields(log.Fields{"e.epoch": e.GetEpoch()}).Debug("Epoch timeout. Repeating epoch")
 				e.vote()
@@ -352,6 +360,39 @@ func (e *ConsensusEngine) mainLoop() {
 			}
 		}
 	}
+}
+
+func (e *ConsensusEngine) serviceReadyVoteTimer() {
+	if e.voteTimer == nil || e.voteTimerReady {
+		return
+	}
+
+	// Do not let priority-message bursts starve a vote timer that is already ready.
+	select {
+	case <-e.voteTimer.C:
+		e.onVoteTimerReady()
+	default:
+	}
+}
+
+func (e *ConsensusEngine) onVoteTimerReady() {
+	e.voteTimerReady = true
+	if e.blockProcessed {
+		e.vote()
+	}
+}
+
+func (e *ConsensusEngine) logLocalVoteTimerNotReadyOnEpochAdvance() {
+	if !e.blockProcessed || e.voteTimerReady {
+		return
+	}
+
+	tip := e.GetTipToVote()
+	e.logger.WithFields(log.Fields{
+		"epoch":      e.GetEpoch(),
+		"tip":        tip.Hash().Hex(),
+		"tip.Height": tip.Height,
+	}).Debug("Epoch advanced before local vote timer was ready")
 }
 
 // enterEpoch is called when engine enters a new epoch.
@@ -851,7 +892,13 @@ func (e *ConsensusEngine) handleNormalBlock(eb *core.ExtendedBlock) {
 	// before block is processed.
 	if localEpoch := e.GetEpoch(); block.Epoch == localEpoch-1 || block.Epoch == localEpoch {
 		e.blockProcessed = true
-		if e.voteTimerReady {
+		shouldVoteNow := e.voteTimerReady
+		if !shouldVoteNow && block.Proposer == e.privateKey.PublicKey().Address() {
+			// A proposer should contribute its vote for its own current tip even if the
+			// vote timer has not fired yet.
+			shouldVoteNow = e.GetTipToVote().Hash() == block.Hash()
+		}
+		if shouldVoteNow {
 			e.vote()
 		}
 	} else {


### PR DESCRIPTION
## Summary
- service a ready local vote timer before and during priority message draining
- allow guarded proposer self-vote when the proposed block is still the current tip to vote for
- add debug telemetry when an epoch advances after block processing before the local vote timer is ready

## Rationale
During the July 9 direct-finalization gap, affected validators had processed the block, but remote priority vote bursts could advance the epoch before the local vote timer case was serviced. Epoch-majority advancement is not the same as a same-block commit certificate, so missing local same-block votes can delay HCC catch-up and direct finalization.

## Testing
- gofmt -w consensus/engine.go
- git diff --check
- go test ./consensus (fails: existing consensus/state_test.go NewState/Load signature drift)